### PR TITLE
Add support for sodium mod

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,7 @@ group = project.maven_group
 
 repositories {
 	maven { url "https://maven.terraformersmc.com/" }
+	maven { url "https://api.modrinth.com/maven" }
 }
 
 dependencies {
@@ -19,6 +20,7 @@ dependencies {
 	modImplementation ("com.terraformersmc:modmenu:${project.modmenu_version}") {
 		exclude module: "fabric-api"
 	}
+	modCompileOnly "maven.modrinth:sodium:${project.sodium_version}"
 }
 
 base {

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,4 @@ archives_base_name=chest-colorizer
 # Dependencies
 fabric_version=0.100.3+1.21
 modmenu_version=11.0.0
+sodium_version=mc1.21-0.5.11

--- a/src/main/java/net/immortaldevs/colorizer/mixin/sodium/WorldSliceMixin.java
+++ b/src/main/java/net/immortaldevs/colorizer/mixin/sodium/WorldSliceMixin.java
@@ -1,0 +1,34 @@
+package net.immortaldevs.colorizer.mixin.sodium;
+
+import me.jellysquid.mods.sodium.client.world.WorldSlice;
+import net.immortaldevs.colorizer.BlockColor;
+import net.immortaldevs.colorizer.ColorManager;
+import net.immortaldevs.colorizer.ColorizerMod;
+import net.immortaldevs.colorizer.block.ColorizedBarrelBlock;
+import net.minecraft.block.BarrelBlock;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
+import net.minecraft.util.math.BlockPos;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(value = WorldSlice.class, remap = false)
+public class WorldSliceMixin {
+
+    @Inject(method = "getBlockState(III)Lnet/minecraft/block/BlockState;", at = @At(value = "RETURN"),cancellable = true)
+    public void modifyBlockState(int x, int y, int z, CallbackInfoReturnable<BlockState> cir) {
+        BlockState state = cir.getReturnValue();
+        if (state != null) {
+            if (state.getBlock() == Blocks.BARREL) {
+                BlockColor color = ColorManager.getColor(new BlockPos(x,y,z));
+                state = ColorizerMod.BARREL_BLOCK.getDefaultState()
+                        .with(ColorizedBarrelBlock.COLOR, color)
+                        .with(BarrelBlock.FACING, state.get(BarrelBlock.FACING))
+                        .with(BarrelBlock.OPEN, state.get(BarrelBlock.OPEN));
+            }
+            cir.setReturnValue(state);
+        }
+    }
+}

--- a/src/main/resources/colorizer.mixins.json
+++ b/src/main/resources/colorizer.mixins.json
@@ -7,7 +7,8 @@
     "BlockMixin",
     "ItemMixin",
     "TexturedRenderLayersMixin",
-    "SectionBuilderMixin"
+    "SectionBuilderMixin",
+    "sodium.WorldSliceMixin"
   ],
   "injectors": {
     "defaultRequire": 1

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -37,5 +37,8 @@
     "fabricloader": ">=0.15",
     "minecraft": ">=1.21 <1.22",
     "java": ">=21"
+  },
+  "suggests": {
+    "sodium": "*"
   }
 }


### PR DESCRIPTION
Noticed when trying out the mod is was only partially compatible with sodium. Colored Chests rendered properly but it seemed as though the redirect in the SectionBuilderMixin was never getting called to render the colored Barrels.

There is probably a better place for this mixin, but it does not help that sodium is in the middle of package renaming. Also new to modding and render is very confusing.

Working with Sodium
![Screenshot 2024-07-25 090041](https://github.com/user-attachments/assets/8c59f3b1-c002-4a48-b5d2-ccb272ebd3a2)
