### PR TITLE
remove mixin WorldSlice remap

### DIFF
--- a/src/main/java/net/immortaldevs/colorizer/mixin/sodium/WorldSliceMixin.java
+++ b/src/main/java/net/immortaldevs/colorizer/mixin/sodium/WorldSliceMixin.java
@@ -14,7 +14,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-@Mixin(value = WorldSlice.class, remap = false)
+@Mixin(value = WorldSlice.class)
 public class WorldSliceMixin {
 
     @Inject(method = "getBlockState(III)Lnet/minecraft/block/BlockState;", at = @At(value = "RETURN"),cancellable = true)


### PR DESCRIPTION
Sorry @kalucky0 for the small PR spam.
When building the remapped jar, and running the mod on a regular fabric client and not in a dev environment, was running into an [error](https://gist.github.com/mahss-io/1917a372e3ce42bd9ebb4c568655aab1) of it being unable to find the sodium class WorldSlice to inject into. Removing the remap property on the mixin seemed to fix it (still functions in the dev environment as well, but I dont fully understand the remapping process).

Dev Env
![Screenshot 2024-07-26 105441](https://github.com/user-attachments/assets/5946fd77-1835-4f3a-be96-20a4d7aa5d81)

Remapped Jar
![Screenshot 2024-07-26 105717](https://github.com/user-attachments/assets/7a550cd2-6dd3-4c2f-8c39-2c7b677fac8f)
